### PR TITLE
Much needed rewrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	@./node_modules/.bin/mocha
+
+.PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 test:
-	@./node_modules/.bin/mocha
+	@./node_modules/.bin/mocha --timeout=20000
 
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -94,3 +94,10 @@ Eg:
 Type: `boolean`
 
 Default: `false`
+
+##### cwd EXPERIMENTAL
+Type: `string`
+
+Default: `undefined`
+
+You can use this to run the specified `cordova` command in a specific directory.

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,3 @@
 machine:
   node:
     version: iojs-1.5.0
-dependencies:
-  override:
-    - npm install --dev

--- a/index.js
+++ b/index.js
@@ -75,12 +75,6 @@ module.exports = function(commands, options) {
     }
 
     wrapper(command, next)
-
-    // var arguments = command.splice(1, Number.MAX_VALUE)
-    // arguments.push(next)
-    //
-    // cordova[command[0]].apply(this, arguments)
-
   }
 
   return map(cordovaStream)

--- a/index.js
+++ b/index.js
@@ -1,72 +1,87 @@
 /*
- * gulp-cordovacli
- * https://github.com/rcsole/gulp-cordovacli
+ * gulp-cordova
+ * https://github.com/rcsole/gulp-cordova
  *
  * Copyright (c) 2015 Ricard Solé Casas
  * Licensed under the MIT license.
  */
 
-var spawn = require('win-spawn')
+var wrapper = require('./wrapper')
 var gutil = require('gulp-util')
 var chalk = require('chalk')
 var map = require('map-stream')
-var eachAsync = require('each-async')
+var async = require('async')
+
+var GULP_CORDOVA = '[gulp-cordova]'
 
 module.exports = function(commands, options) {
 
+  var endStream = null
   var opts = options || {}
+  opts.rootDir = process.cwd()
 
-  function cordova(file, cb) {
-    if (!file && !commands) {
-      return cb(new gutil.PluginError('[gulp-cordovacli]', 'Please provide either a config file or a command object'))
+  function cordovaError(message) {
+    return new gutil.PluginError({
+      plugin: GULP_CORDOVA,
+      message: message
+    })
+  }
+
+  function cordovaStream(file, callback) {
+    endStream = callback
+
+    if (!file.contents && !commands) {
+      return endStream(new cordovaError('Please provide either a config file or a command object'))
     }
 
-    if (file && !commands) {
+    if (file.contents && !commands) {
       commands = JSON.parse(file.contents.toString()).cordova
     }
 
     if (!Array.isArray(commands)) {
-      return cb(new gutil.PluginError('[gulp-cordovacli]', 'commands must be an array'))
+      return endStream(new cordovaError('Commands must be an array'))
     }
 
     if (!Array.isArray(commands[0])) {
       commands = [commands]
     }
 
-    eachAsync(commands, function(command, i, next) {
-      runCommand(command, next, cb)
-    }, cb)
+    async.eachSeries(commands, function(command, next) {
+      execute(command, next)
+    }, function(err) {
+
+      if (!opts.silent) {
+        gutil.log(GULP_CORDOVA,
+          'Going back to root directory:',
+          opts.rootDir
+        )
+      }
+
+      process.chdir(opts.rootDir)
+      endStream()
+    })
   }
 
-  function runCommand(command, next, cb) {
-    var opts = options ? options : {}
-    var cordova = spawn('cordova', command)
+  function execute(command, next) {
 
-    if (!opts.silent) {
-      gutil.log('[gulp-cordovacli]', 'Running command:', chalk.magenta('cordova'), chalk.cyan(command.join(' ')))
+    if (opts.cwd) {
+      process.chdir(opts.cwd)
     }
 
-    cordova.stdout.setEncoding('utf-8')
-    cordova.stderr.setEncoding('utf-8')
+    if (!opts.silent) {
+      gutil.log(GULP_CORDOVA,
+        'Running command:', chalk.magenta('cordova'), chalk.cyan(command.join(' ')),
+        'in', process.cwd())
+    }
 
-    cordova.stdout.on('data', function(data) {
-      if (opts.verbose) {
-        gutil.log('[gulp-cordovacli]', chalk.blue(data))
-      }
-    })
+    wrapper(command, next)
 
-    cordova.stderr.on('data', function(data) {
-      if (opts.verbose) {
-        gutil.log('[gulp-cordovacli]', chalk.yellow(data))
-      }
+    // var arguments = command.splice(1, Number.MAX_VALUE)
+    // arguments.push(next)
+    //
+    // cordova[command[0]].apply(this, arguments)
 
-      return cb()
-    })
-
-    cordova.on('close', function() {
-      next()
-    })
   }
 
-  return map(cordova)
+  return map(cordovaStream)
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Wraps a web application as a hybrid app with Apache Cordova CLI 4.x.x",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --timeout=20000"
+    "test": "make test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chalk": "^1.0.0",
     "cordova-lib": "^4.3.0",
     "gulp-util": "^3.0.1",
+    "lodash": "^3.5.0",
     "map-stream": "0.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gulp-cordovacli",
+  "name": "gulp-cordova",
   "version": "0.0.4",
-  "description": "Wraps a web application as a hybrid app with Apache Cordova CLI 4.x.x",
+  "description": "Wraps a web application as a hybrid app with Apache Cordova lib 4.x.x",
   "main": "index.js",
   "scripts": {
     "test": "make test"
@@ -14,6 +14,7 @@
     "gulpplugin",
     "gulp",
     "cordova",
+    "cordova-lib",
     "cordova-cli",
     "phonegap"
   ],
@@ -24,12 +25,11 @@
   },
   "homepage": "https://github.com/rcsole/gulp-cordovacli",
   "dependencies": {
-    "chalk": "^0.5.1",
-    "each-async": "^1.1.1",
+    "async": "^0.9.0",
+    "chalk": "^1.0.0",
     "cordova-lib": "^4.3.0",
     "gulp-util": "^3.0.1",
-    "map-stream": "0.0.5",
-    "win-spawn": "^2.0.0"
+    "map-stream": "0.0.5"
   },
   "devDependencies": {
     "gulp": "^3.8.10",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "each-async": "^1.1.1",
+    "cordova-lib": "^4.3.0",
     "gulp-util": "^3.0.1",
     "map-stream": "0.0.5",
     "win-spawn": "^2.0.0"

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,7 @@
+process.env.NODE_ENV = 'test'
+
+var child = require('child_process')
+
 var gulp = require('gulp')
 var assert = require('assert')
 var fs = require('fs')
@@ -7,75 +11,90 @@ var rm = require('rimraf')
 var cordova = require('../')
 
 describe('gulp-cordovacli', function() {
+  var CONFIG_FILE = './test/fixtures.json'
+
+  it('should emit an error if no commands and no file are provided', function(done) {
+    gulp.src('.')
+      .pipe(cordova())
+      .on('error', function(err) {
+        assert(err)
+        done()
+      })
+  })
 
   beforeEach(function(done) {
     gulp.src('.')
       .pipe(cordova(['create', 'test/test', 'test.test.test', 'Test'], { silent: true }))
       .on('close', function() {
-        process.chdir('test/test')
         done()
       })
   })
 
   afterEach(function(done) {
-    process.chdir('../../')
-    rm('test/test', function() {
+    rm('./test/test', function() {
       done()
     })
   })
 
-  describe('using a configuration file', function() {
-    var CONFIG_FILE = '../fixtures.json'
-
-    it('should run the commands from the configuration file', function(done) {
-      gulp.src(CONFIG_FILE)
-        .pipe(cordova(false, { silent: true }))
-        .on('close', function() {
-          assert.equal(true, fs.existsSync(__dirname + '/test/platforms/browser'))
-
-          done()
-        })
-    })
-
-    it('explicit commands should override configuration file', function(done) {
-      gulp.src(CONFIG_FILE)
-        .pipe(cordova(['build'], { silent: true }))
-        .on('close', function() {
-          assert.equal(false, fs.existsSync(__dirname + '/test/platforms/browser'))
-
-          done()
-        })
-    })
+  after(function () {
+    child.exec('rm -rf ./test/test');
   })
 
-  describe('without a configuration file', function() {
-    it('should run the given commands', function (done) {
-      gulp.src('.')
-        .pipe(cordova(['platforms', 'add', 'browser'], { silent: true }))
-        .on('close', function() {
-          assert.equal(true, fs.existsSync(__dirname + '/test/platforms/browser'))
+  it('should run the commands from the configuration file', function(done) {
+    gulp.src(CONFIG_FILE)
+      .pipe(cordova(false, { silent: true, cwd: __dirname + '/test' }))
+      .on('close', function() {
+        assert.equal(true, fs.existsSync(__dirname + '/test/platforms/browser'))
 
-          done()
-        })
-    });
+        done()
+      })
+  })
 
-    it('should run multiple commands', function (done) {
-      gulp.src('.')
-        .pipe(cordova([[
-            "plugin",
-            "add",
-            "org.apache.cordova.device"
-          ],[
-            "platform",
-            "add",
-            "browser"
-          ]], { silent: true }))
-        .on('close', function() {
-          assert.equal(true, fs.existsSync(__dirname + '/test/platforms/browser'))
-          assert.equal(true, fs.existsSync(__dirname + '/test/plugins/org.apache.cordova.device'))
+  it('explicit commands should override configuration file', function(done) {
+    gulp.src(CONFIG_FILE)
+      .pipe(cordova([[
+        'platform',
+        'add',
+        'browser'
+      ],
+      [
+        'platform',
+        'rm',
+        'browser'
+      ]], { silent: true, cwd: __dirname + '/test' }))
+      .on('close', function() {
+        assert.equal(false, fs.existsSync(__dirname + '/test/platforms/browser'))
 
-          done()
-        })
-    })
+        done()
+      })
+  })
+
+  it('should run the given commands', function (done) {
+    gulp.src('.')
+      .pipe(cordova(['platforms', 'add', 'browser'], { silent: true, cwd: __dirname + '/test' }))
+      .on('close', function() {
+        assert.equal(true, fs.existsSync(__dirname + '/test/platforms/browser'))
+
+        done()
+      })
+  });
+
+  it('should run multiple commands', function (done) {
+    gulp.src('.')
+      .pipe(cordova([[
+          "plugin",
+          "add",
+          "org.apache.cordova.device"
+        ],[
+          "platform",
+          "add",
+          "browser"
+        ]], { silent: true, cwd: __dirname + '/test' }))
+      .on('close', function() {
+        assert.equal(true, fs.existsSync(__dirname + '/test/platforms/browser'))
+        assert.equal(true, fs.existsSync(__dirname + '/test/plugins/org.apache.cordova.device'))
+
+        done()
+      })
   })
 })

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,0 +1,89 @@
+/*
+ * Extracted from https://github.com/apache/cordova-cli/blob/master/src/cli.js
+ *
+ * gulp-cordova
+ * https://github.com/rcsole/gulp-cordova
+ *
+ * Copyright (c) 2015 Ricard Solé Casas
+ * Licensed under the MIT license.
+ */
+
+var cordova_lib = require('cordova-lib')
+var _ = require('lodash')
+var cordova = cordova_lib.cordova
+var events = cordova_lib.events
+
+function cordovaWrapper(commandArray, next) {
+
+  var cmd = commandArray[0]
+  var subcommand
+  var msg
+  var known_platforms = Object.keys(cordova_lib.cordova_platforms)
+
+  if (!cordova.hasOwnProperty(cmd)) {
+    return callback('Cordova does not know ' + cmd)
+  }
+
+  var opts = {
+    platforms: [],
+    options: [],
+    verbose: false,
+    silent: true,
+    browserify: false
+  }
+
+  if (cmd == 'emulate' || cmd == 'build' || cmd == 'prepare' || cmd == 'compile' || cmd == 'run') {
+
+    opts.platforms = commandArray.slice(1)
+    var badPlatforms = _.difference(opts.platforms, known_platforms)
+    if (!_.isEmpty(badPlatforms)) {
+      return callback('Unknown platforms: ' + badPlatforms.join(', '))
+    }
+
+    // CB-6976 Windows Universal Apps. Allow mixing windows and windows8 aliases
+    opts.platforms = opts.platforms.map(function(platform) {
+      // allow using old windows8 alias for new unified windows platform
+      if (platform == 'windows8' && fs.existsSync('platforms/windows')) {
+        return 'windows'
+      }
+      // allow using new windows alias for old windows8 platform
+      if (platform == 'windows' &&
+        !fs.existsSync('platforms/windows') &&
+        fs.existsSync('platforms/windows8')) {
+        return 'windows8'
+      }
+      return platform
+    })
+
+    if (cmd == 'run' && args.list && cordova.raw.targets) {
+      cordova.raw.targets.call(null, opts).done(next)
+      return
+    }
+
+    cordova.raw[cmd].call(null, opts).done(next)
+  } else if (cmd == 'serve') {
+    var port = commandArray[1]
+    cordova.raw.serve(port).done(next)
+  } else if (cmd == 'create') {
+    var cfg = {}
+      // If we got a fourth parameter, consider it to be JSON to init the config.
+    if (commandArray[4]) {
+      cfg = JSON.parse(commandArray[4])
+    }
+
+    // create(dir, id, name, cfg)
+    cordova.raw.create(commandArray[1] // dir to create the project in
+      , commandArray[2] // App id
+      , commandArray[3] // App name
+      , cfg
+    ).done(next)
+  } else {
+    // platform/plugins add/rm [target(s)]
+    subcommand = commandArray[1] // sub-command like "add", "ls", "rm" etc.
+    var targets = commandArray.slice(2) // array of targets, either platforms or plugins
+    cordova.raw[cmd](subcommand.toString(), targets).done(next)
+  }
+
+}
+
+module.exports = cordovaWrapper


### PR DESCRIPTION
This drops the `cordova-cli` dependency in favor raw `cordova-lib` instead.
I've extracted the `cordova` wrapper from `cordova-cli` to interact with the
`cordova` API.

* Support for changing directory has been added as well
* The close event should be correctly emitted now
* Might solve #3 

Since we no longer depend on an spawned process this should be more
reliable than the previous versions.

This will be released as a pre-release and under a new name `gulp-cordova`
since it no longer uses `cordova-cli` it makes sense to rename it. If I could get
some help with testing @aintnorest that would be awesome :dancer: :dancer: 

* [x] Update README